### PR TITLE
Reactivate noarch package with the ability to generate egg package

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -8,16 +8,17 @@ source:
   path: ..
 
 build:
+  noarch: python
   preserve_egg_dir: True
-  number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  number: 1
+  script: python setup.py install #--single-version-externally-managed --record=record.txt
 
 requirements:
   build:
-    - python {{PY_VER}}
+    - python 
     - openalea.deploy
   run:
-    - python {{PY_VER}}
+    - python >=3.6
     - openalea.plantgl
     - matplotlib
     - pandas


### PR DESCRIPTION
Noarch packages are possible when removing these options:

    python setup.py install #--single-version-externally-managed --record=record.txt