### PR TITLE
[FIX] Add an option to remove warnings

### DIFF
--- a/src/openalea/mtg/interface/mtg.py
+++ b/src/openalea/mtg/interface/mtg.py
@@ -18,7 +18,7 @@
 This module provides multiscale tree concepts to form MTG interface.
 """
 
-class MultiscaleTreeConcept(object):
+class MultiscaleTreeConcept():
     """
     Multiscale Tree Graph definition.
     """

--- a/src/openalea/mtg/mtg.py
+++ b/src/openalea/mtg/mtg.py
@@ -2753,7 +2753,7 @@ def return_tuple_proxy(f):
     new_f.__doc__ = mtg_f.__doc__
     return new_f
 
-class _ProxyNode(object):
+class _ProxyNode():
     def __init__(self, g, vid):
         self.__dict__['_g'] = g
         self.__dict__['_vid'] = vid

--- a/src/openalea/mtg/mtg.py
+++ b/src/openalea/mtg/mtg.py
@@ -67,7 +67,7 @@ class MTG(PropertyTree):
 
     '''
 
-    def __init__(self, filename='', has_date=False):
+    def __init__(self, filename='', has_date=False, verbose=False):
         ''' Create a new MTG object.
 
         :Usage:
@@ -77,6 +77,8 @@ class MTG(PropertyTree):
         '''
 
         super(MTG, self).__init__()
+
+        self.verbose = verbose
 
         # Map a vid to its scale
         self._scale = {0:0}
@@ -93,7 +95,9 @@ class MTG(PropertyTree):
 
         if filename:
             from .io import read_mtg_file
-            self = read_mtg_file(filename, mtg=self, has_date=has_date)
+            self = read_mtg_file(filename, mtg=self, has_date=has_date, verbose=verbose)
+
+        
 
     def __getitem__(self, vtx_id):
         """A simple getitem to extract relevant information on a vertex.
@@ -2389,7 +2393,8 @@ def _compute_missing_edges(mtg, scale, edge_type_property=None):
     for vid in roots:
         components = mtg._components.get(vid)
         if components is None:
-            print('ERROR: Missing component for vertex %d'%vid)
+            if mtg.verbose: 
+                print('ERROR: Missing component for vertex %d'%vid)
             continue
         #assert len(components) == 1
         cid = components[0]
@@ -2398,7 +2403,8 @@ def _compute_missing_edges(mtg, scale, edge_type_property=None):
         parent_id = mtg.complex(mtg.parent(cid))
         if parent_id is None:
             #roots.append(vid)
-            print('ERROR: Missing parent for vertex %d'%cid)
+            if mtg.verbose:
+                print('ERROR: Missing parent for vertex %d'%cid)
             continue
         if edge_type_property:
             edge_type = edge_type_property.get(cid)

--- a/src/openalea/mtg/plantframe/dresser.py
+++ b/src/openalea/mtg/plantframe/dresser.py
@@ -43,7 +43,7 @@ from math import pi
 import os
 from openalea.plantgl.scenegraph import AmapSymbol
 
-class DressingData(object):
+class DressingData():
     """ Data and default geometric parameters.
 
     The dressing data are the default data that are used to define 
@@ -205,7 +205,7 @@ def dressing_data(file):
 
 ###############################################################
 ## Define the parser which is just a dict from keyword to a function 
-class Reader(object):
+class Reader():
     def __init__(self, dresser):
         self.dresser = dresser
         

--- a/src/openalea/mtg/plantframe/frame.py
+++ b/src/openalea/mtg/plantframe/frame.py
@@ -34,7 +34,7 @@ from openalea.mtg.traversal import post_order
 
 
 
-class Frame(object):
+class Frame():
     """ Frame representing geometric variables of each topologic elements.
     
     A frame is used to have a common representation of the geometric information 
@@ -137,7 +137,7 @@ class Frame(object):
     top_radius = property(get_top_radius, set_top_radius, 'top_radius of the Frame')
 
 
-class AxialFrames(object):
+class AxialFrames():
     ''' Solve continuity constraints on an axis, i.e. a set of frames.
 
     '''
@@ -145,7 +145,7 @@ class AxialFrames(object):
 
 
 
-class PlantFrame(object):
+class PlantFrame():
     ''' Engine to compute the geometry of a plant based on 
     its topological description and parameters.
     '''

--- a/src/openalea/mtg/plantframe/plantframe.py
+++ b/src/openalea/mtg/plantframe/plantframe.py
@@ -56,7 +56,7 @@ from openalea.plantgl.all import *
 error = True
 epsilon = 1e-5
 
-class PlantFrame(object):
+class PlantFrame():
     ''' Engine to compute the geometry of a plant based on
     its topological description and parameters.
     '''

--- a/src/openalea/mtg/rewriting.py
+++ b/src/openalea/mtg/rewriting.py
@@ -20,7 +20,7 @@ from .mtg import _ProxyNode, MTG
 
 #### Module declaration #######
 
-class Module(object):
+class Module():
     def __init__(self, name, scale, **parameters):
         self.name = name
         self.scale = scale
@@ -299,7 +299,7 @@ def interpretation(f):
 
 eForward, eBackward = 1,0
 
-class MTGLsystem(object):
+class MTGLsystem():
     rules = dict()
 
     def __init__(self):

--- a/src/openalea/mtg/traversal.py
+++ b/src/openalea/mtg/traversal.py
@@ -271,7 +271,7 @@ def traverse_tree(tree, vtx_id, visitor):
   yield visitor.post_order(vtx_id)
 
 
-class Visitor(object):
+class Visitor():
   ''' Used during a tree traversal. '''
 
   def pre_order(self, vtx_id): 

--- a/src/openalea/mtg/tree.py
+++ b/src/openalea/mtg/tree.py
@@ -43,7 +43,7 @@ class InvalidVertex (GraphError, KeyError) :
     exception raised when a wrong vertex id is provided
     """
 
-class Tree(object):
+class Tree():
     '''
     Implementation of a rooted :class:`Tree`, 
     with methods to add and remove vertex.

--- a/src/openalea/mtg/version.py
+++ b/src/openalea/mtg/version.py
@@ -7,7 +7,7 @@ major = 2
 minor = 2
 """(int) Version minor component."""
 
-post = 0
+post = 1
 """(int) Version post or bugfix component."""
 
 __version__ = ".".join([str(s) for s in (major, minor, post)])


### PR DESCRIPTION
Close issue #39

Some analysis are very verbose. Warnings are really usefull for debugging MTG acquired in the field.
However, some warnings may be unjustified and when debuged we want the the read of MTG be silent!

We add an option by default of the verbose mode.
When false, nothing is printed. 