### PR TITLE
switch matplotlib deps to matplotlib-base

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 keywords = ["OpenAlea", "MTG", "Plant Architecture", "Tree Graph"]
 
 dependencies = [
-    "matplotlib",
+    "matplotlib-base",
     "pandas"
 ]
 


### PR DESCRIPTION
Use matlplotlib base in deps, to avoid pyside loading and qt6 clobbering pb on windows